### PR TITLE
Render liquid shape filter as a true Blazor component

### DIFF
--- a/src/framework/BlazingOrchard.DisplayManagement/Services/IShapeRenderer.cs
+++ b/src/framework/BlazingOrchard.DisplayManagement/Services/IShapeRenderer.cs
@@ -2,12 +2,19 @@
 using System.Threading.Tasks;
 using BlazingOrchard.DisplayManagement.Shapes;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 
 namespace BlazingOrchard.DisplayManagement.Services
 {
     public interface IShapeRenderer
     {
         Task<RenderFragment> RenderShapeAsync(IShape shape, CancellationToken cancellationToken = default);
+
+        Task<int> RenderShapeAsync(IShape shape,
+            int sequence,
+            RenderTreeBuilder renderTreeBuilder,
+            CancellationToken cancellationToken = default);
+
         Task<string> RenderShapeAsStringAsync(IShape shape, CancellationToken cancellationToken = default);
     }
 }

--- a/src/modules/BlazingOrchard.Liquid/Components/LiquidPart.razor
+++ b/src/modules/BlazingOrchard.Liquid/Components/LiquidPart.razor
@@ -1,7 +1,8 @@
 ﻿@inherits ShapeTemplate
-@Html
 
+@RenderLiquid
 @code
 {
-    private MarkupString Html => (MarkupString)Model.Html;
+    //private MarkupString Html => (MarkupString)Model.Html;
+    private RenderFragment RenderLiquid => (RenderFragment)Model.RenderLiquid;
 }

--- a/src/modules/BlazingOrchard.Liquid/Drivers/LiquidPartDisplay.cs
+++ b/src/modules/BlazingOrchard.Liquid/Drivers/LiquidPartDisplay.cs
@@ -1,9 +1,13 @@
-﻿using System.Text.Encodings.Web;
+﻿using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using BlazingOrchard.Contents.Display.Services;
 using BlazingOrchard.DisplayManagement.Services;
 using BlazingOrchard.DisplayManagement.Shapes;
 using BlazingOrchard.Liquid.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 
 namespace BlazingOrchard.Liquid.Drivers
 {
@@ -28,17 +32,61 @@ namespace BlazingOrchard.Liquid.Drivers
                         shape.ContentItem = contentPart.ContentItem;
                         shape.Liquid = contentPart.Liquid!;
                         shape.LiquidBodyPart = contentPart;
-                        shape.Html = (await ToHtmlAsync(contentPart, shape)) ?? "";
+                        //shape.Html = (await ToHtmlAsync(contentPart, shape)) ?? "";
+                        shape.RenderLiquid = (RenderFragment)(b => RenderLiquid(b, contentPart, shape));
+                        
                         return shape;
                     })
                 .DefaultLocation("5");
         }
 
-        private async Task<string?> ToHtmlAsync(LiquidPart liquidPart, IShape shape) =>
-            await _liquidTemplateManager.RenderAsync(
+        private void RenderLiquid(RenderTreeBuilder builder, LiquidPart liquidPart, IShape shape)
+        {
+            var writer = new RenderTreeWriter(builder);
+            
+            _liquidTemplateManager.RenderAsync(
+                liquidPart.Liquid,
+                writer,
+                _htmlEncoder,
+                shape,
+                scope => { scope.SetValue("ContentItem", liquidPart.ContentItem); }).GetAwaiter().GetResult();
+            
+            //builder.AddMarkupContent(0, "<strong>Hey, it's me!</strong>");
+        }
+
+        private async Task<string?> ToHtmlAsync(LiquidPart liquidPart, IShape shape)
+        {
+            return await _liquidTemplateManager.RenderAsync(
                 liquidPart.Liquid,
                 _htmlEncoder,
                 shape,
-                scope => scope.SetValue("ContentItem", liquidPart.ContentItem));
+                scope => { scope.SetValue("ContentItem", liquidPart.ContentItem); });
+        }
+    }
+
+    internal class RenderTreeWriter : TextWriter
+    {
+        private readonly RenderTreeBuilder _builder;
+        private int _sequence;
+
+        public RenderTreeWriter(RenderTreeBuilder builder)
+        {
+            _builder = builder;
+        }
+        
+        public override Encoding Encoding { get; }
+
+        public override void Write(string? value)
+        {
+            _builder.AddMarkupContent(_sequence++, value);
+            //base.Write(value);
+        }
+
+        public override Task WriteAsync(string? value)
+        {
+            _builder.AddMarkupContent(_sequence++, value);
+            return Task.CompletedTask;
+            //return base.WriteAsync(value);
+        }
     }
 }

--- a/src/modules/BlazingOrchard.Liquid/Extensions/LiquidViewTemplateExtensions.cs
+++ b/src/modules/BlazingOrchard.Liquid/Extensions/LiquidViewTemplateExtensions.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using BlazingOrchard.Liquid.Models;
 using BlazingOrchard.Liquid.Services;
 using Fluid;
 

--- a/src/modules/BlazingOrchard.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/modules/BlazingOrchard.Liquid/Filters/LiquidViewFilters.cs
@@ -15,19 +15,19 @@ namespace BlazingOrchard.Liquid.Filters
 {
     public static class LiquidViewFilters
     {
-        private static readonly AsyncFilterDelegate _htmlClassDelegate = HtmlClass;
-        private static readonly AsyncFilterDelegate _newShapeDelegate = NewShape;
-        private static readonly AsyncFilterDelegate _shapeRenderDelegate = ShapeRender;
-        private static readonly AsyncFilterDelegate _shapeStringifyDelegate = ShapeStringify;
-        private static readonly FilterDelegate _shapePropertiesDelegate = ShapeProperties;
+        private static readonly AsyncFilterDelegate HtmlClassDelegate = HtmlClass;
+        private static readonly AsyncFilterDelegate NewShapeDelegate = NewShape;
+        private static readonly AsyncFilterDelegate ShapeRenderDelegate = ShapeRender;
+        private static readonly AsyncFilterDelegate ShapeStringifyDelegate = ShapeStringify;
+        private static readonly FilterDelegate ShapePropertiesDelegate = ShapeProperties;
 
         public static FilterCollection WithLiquidViewFilters(this FilterCollection filters)
         {
-            filters.AddAsyncFilter("html_class", _htmlClassDelegate);
-            filters.AddAsyncFilter("shape_new", _newShapeDelegate);
-            filters.AddAsyncFilter("shape_render", _shapeRenderDelegate);
-            filters.AddAsyncFilter("shape_stringify", _shapeStringifyDelegate);
-            filters.AddFilter("shape_properties", _shapePropertiesDelegate);
+            filters.AddAsyncFilter("html_class", HtmlClassDelegate);
+            filters.AddAsyncFilter("shape_new", NewShapeDelegate);
+            filters.AddAsyncFilter("shape_render", ShapeRenderDelegate);
+            filters.AddAsyncFilter("shape_stringify", ShapeStringifyDelegate);
+            filters.AddFilter("shape_properties", ShapePropertiesDelegate);
 
             return filters;
         }

--- a/src/modules/BlazingOrchard.Liquid/Fluidtypes/ShapeValue.cs
+++ b/src/modules/BlazingOrchard.Liquid/Fluidtypes/ShapeValue.cs
@@ -3,30 +3,31 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Encodings.Web;
+using BlazingOrchard.DisplayManagement.Shapes;
 using Fluid;
 using Fluid.Values;
 
 namespace BlazingOrchard.Liquid.FluidTypes
 {
-    public class HtmlContentValue : FluidValue
+    public class ShapeValue : FluidValue
     {
-        private readonly string? _value;
-        public HtmlContentValue(string value) => _value = value;
+        private readonly IShape? _value;
+        public ShapeValue(IShape value) => _value = value;
         public override FluidValues Type => FluidValues.String;
 
         public override bool Equals(FluidValue other) =>
-            other.IsNil() ? _value == null : _value != null && _value == other.ToStringValue();
+            other.IsNil() ? _value == null : _value != null && Equals(_value, other.ToObjectValue());
 
         protected override FluidValue GetIndex(FluidValue index, TemplateContext context) => NilValue.Instance;
         protected override FluidValue GetValue(string name, TemplateContext context) => NilValue.Instance;
         public override bool ToBooleanValue() => true;
         public override decimal ToNumberValue() => 0;
-        public override string ToStringValue() => _value!;
+        public override string ToStringValue() => _value?.Metadata.Type!;
 
         public override void WriteTo(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
         {
             if (_value != null)
-                writer.Write(_value, (HtmlEncoder)encoder);
+                writer.Write(_value);
         }
 
         public override object ToObjectValue() => _value!;
@@ -34,7 +35,7 @@ namespace BlazingOrchard.Liquid.FluidTypes
         public override IEnumerable<FluidValue> Enumerate() => Enumerable.Empty<FluidValue>();
 
         public override bool Equals(object? other) =>
-            other is HtmlContentValue otherValue && Equals(_value, otherValue._value);
+            other is ShapeValue otherValue && Equals(_value, otherValue._value);
 
         public override int GetHashCode() => _value != null ? _value.GetHashCode() : 0;
     }

--- a/src/modules/BlazingOrchard.Liquid/Models/LiquidViewTemplate.cs
+++ b/src/modules/BlazingOrchard.Liquid/Models/LiquidViewTemplate.cs
@@ -6,7 +6,7 @@ using BlazingOrchard.Liquid.Tags;
 using Fluid;
 using Fluid.Values;
 
-namespace BlazingOrchard.Liquid.Services
+namespace BlazingOrchard.Liquid.Models
 {
     public class LiquidViewTemplate : BaseFluidTemplate<LiquidViewTemplate>
     {

--- a/src/modules/BlazingOrchard.Liquid/TextWriters/ShapeWriter.cs
+++ b/src/modules/BlazingOrchard.Liquid/TextWriters/ShapeWriter.cs
@@ -1,0 +1,34 @@
+﻿using System.IO;
+using System.Text;
+using BlazingOrchard.DisplayManagement.Services;
+using BlazingOrchard.DisplayManagement.Shapes;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace BlazingOrchard.Liquid.TextWriters
+{
+    internal class ShapeWriter : TextWriter
+    {
+        private readonly RenderTreeBuilder _builder;
+        private readonly IShapeRenderer _shapeRenderer;
+        private int _sequence;
+
+        public ShapeWriter(RenderTreeBuilder builder, IShapeRenderer shapeRenderer)
+        {
+            _builder = builder;
+            _shapeRenderer = shapeRenderer;
+        }
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(object? value)
+        {
+            if (value is IShape shape)
+            {
+                _sequence = _shapeRenderer.RenderShapeAsync(shape, _sequence, _builder).GetAwaiter().GetResult();
+                return;
+            }
+
+            base.Write(value);
+        }
+    }
+}


### PR DESCRIPTION
Originally, when rendering shapes via liquid would result in those shapes being "stringified" and emitted as HTML markup strings to the Blazor render tree.

This PR changes this such that components are directly emitted to the render tree. Which has the obvious benefit of retaining component functionalities.